### PR TITLE
HCK-7662: enable the feature for primary keys in nested attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
                 "jsonSchema": true,
                 "excel": true,
                 "plugin": true
-            }
+            },
+            "restrictNestedFieldsAsPrimaryKey": false
         }
     },
     "description": "Hackolade plugin for MarkLogic",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7662" title="HCK-7662" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-7662</a>  [BNSF,JMFamily][Document-targets] It should be allowed for attributes inside nested objects to be marked as PK
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
